### PR TITLE
Call _endTest() with error object to fix messaging for test failures.

### DIFF
--- a/lib/nodeunitAsync.js
+++ b/lib/nodeunitAsync.js
@@ -52,12 +52,8 @@ NodeunitAsync.listeningForUncaughtExceptions = false;
 NodeunitAsync.initUncaughtExceptionListener = function() {
     process.on('uncaughtException', function(err) {
 
-        console.log(colors.red('Uncaught Exception'));
-        console.log(colors.red(err.message));
-        console.log(colors.red(err.stack));
-
         if (NodeunitAsync.activeNodeunitAync) {
-            NodeunitAsync.activeNodeunitAync._endTest();
+            NodeunitAsync.activeNodeunitAync._endTest(err);
         } else {
             console.log(colors.yellow('Unable to determine current test error encountered in, re-throwing'));
             throw err;
@@ -118,10 +114,7 @@ NodeunitAsync.prototype.runTest = function(test, testMethods) {
             self.globalTeardown ? self.globalTeardown(next) : next();
         }]
     }, function(err) {
-        if (err) {
-            throw err;
-        }
-        self._endTest();
+        self._endTest(err);
     });
 };
 
@@ -151,7 +144,7 @@ NodeunitAsync.prototype._startTest = function() {
  * Ends a test
  * @private
  */
-NodeunitAsync.prototype._endTest = function() {
+NodeunitAsync.prototype._endTest = function(error) {
     if (this._lastTeardownTimebomb) {
         throw new Error('Unexpected overlapping of fixtureTeardown');
     }
@@ -159,7 +152,7 @@ NodeunitAsync.prototype._endTest = function() {
     if (this.fixtureTeardown) {
         this._lastTeardownTimebomb = new Timebomb(this.fixtureTeardownDelayMs, this.fixtureTeardown);
     }
-    this._currentTest.done();
+    this._currentTest.done(error);
     this._currentTest = null;
     NodeunitAsync.activeNodeunitAync = null;
 };

--- a/test/testNodeunitAsync.js
+++ b/test/testNodeunitAsync.js
@@ -102,18 +102,14 @@ exports.testWithFailures = function(test) {
             'Error: Auto Thrown Error',
             'testAysncTestWaterfallCallbackError',
             'global setup',
-            'Uncaught Exception',
-            'Waterfall Callback Error',
-            'Error: Waterfall Callback Error',
             '✖ testAysncTestWaterfallCallbackError',
             'Error: Expected 1 assertions, 0 ran',
+            'Error: Waterfall Callback Error',
             'testAysncTestWaterfallThrownError',
             'global setup',
-            'Uncaught Exception',
-            'Waterfall Callback Error',
-            'Error: Waterfall Callback Error',
             '✖ testAysncTestWaterfallThrownError',
             'Error: Expected 1 assertions, 0 ran',
+            'Error: Waterfall Callback Error',
             'testSyncTestThrownError',
             'global setup',
             '✖ testSyncTestThrownError',
@@ -122,13 +118,11 @@ exports.testWithFailures = function(test) {
             'global setup',
             'global teardown',
             '✔ testThatWillPass',
-            'FAILURES: 7/9 assertions failed'
+            'FAILURES: 9/11 assertions failed'
         ];
-        if (err) {
-            throw err;
-        }
+
         test.deepEqual(expectedLines, output);
-        test.done();
+        test.done(err);
     });
 };
 


### PR DESCRIPTION
So they don't just say 'expected x assertions, 0 ran'